### PR TITLE
Added source URL to Image Zoom.js

### DIFF
--- a/Image Zoom/Image Zoom.js
+++ b/Image Zoom/Image Zoom.js
@@ -1,3 +1,7 @@
+// Trilium Notes Image Zoom Widget
+// check for updates:
+// https://github.com/Nriver/image-zoom-widget/releases
+
 class ImagePreviewWidget extends api.NoteContextAwareWidget {
     get position() {
         return 100;


### PR DESCRIPTION
I think it would be helpful to have at least the repo URL at the top of the Image Zoom code. Makes it easier to remember where one got it from and where to check for updates.